### PR TITLE
refactor: update rateLimit and remove interval in http_client.go

### DIFF
--- a/back/pocket/http_client.go
+++ b/back/pocket/http_client.go
@@ -18,9 +18,8 @@ type Client struct {
 	lastCallTime time.Time
 	rateLimit    time.Duration
 
-	token    string
-	appInfo  string
-	interval int
+	token   string
+	appInfo string
 }
 
 func newClient(token string, appInfo map[string]string, interval int) *Client {
@@ -28,10 +27,9 @@ func newClient(token string, appInfo map[string]string, interval int) *Client {
 	c := Client{
 		mu:           sync.Mutex{},
 		lastCallTime: time.Time{},
-		rateLimit:    0,
+		rateLimit:    time.Duration(interval) * time.Millisecond,
 		token:        token,
 		appInfo:      cm.JsonMarshal(appInfo),
-		interval:     interval,
 	}
 	return &c
 }


### PR DESCRIPTION
Removed the 'interval' field from the struct and updated 'rateLimit' to use 'time.Duration'. This change is done to handle the rate limiting in a more efficient manner.